### PR TITLE
Init round while expanding

### DIFF
--- a/src/controllers/MCTSExpectimax/MCTSETreeNode.java
+++ b/src/controllers/MCTSExpectimax/MCTSETreeNode.java
@@ -94,7 +94,9 @@ public class MCTSETreeNode {
 //        StateObserver2048 childSo = (StateObserver2048) so.copy();		// /WK/ can be done w/o using StateObserver2048:
         StateObservation childSo = so.copy();
         childSo.advance(action);
-    	
+    	if(childSo.isRoundOver())
+    		childSo.initRound();
+
         for (MCTSEChanceNode childrenNode : childrenNodes) {
 //          if (childrenNode.so.equals(childSo)) {		// OLD (before 03/2021) AND WRONG !!
 			if (childrenNode.so.stringDescr().equals(childSo.stringDescr())) {

--- a/src/games/BlackJack/StateObserverBlackJack.java
+++ b/src/games/BlackJack/StateObserverBlackJack.java
@@ -442,7 +442,7 @@ public class StateObserverBlackJack extends ObserverBase implements StateObsNond
 
     @Override
     public ACTIONS getAction(int i) {
-        return ACTIONS.fromInt(i);
+        return availableActions.get(i);
     }
 
     @Override


### PR DESCRIPTION
While using MCTSE uct() returns null at some point which causes a NPE. This happend everytime the state reached a round-over situation. Therefore the "init-round-while-expanding" commit adds an initRound() while expanding in MCTSTreenode which resolved this issue for me.

While using MCTSE rollerState.advance(rollerState.getAction(action)); reached illegal gamestates because the getAction(int i) method of StateObserverBlackJack was implemented for a different logic. This led to NPE as well. The "fixes-getAction(i)" commit resolves this issue. 

