### PR TITLE
Making MCTSE fit for Blackjack, part 2

### DIFF
--- a/src/games/BlackJack/StateObserverBlackJack.java
+++ b/src/games/BlackJack/StateObserverBlackJack.java
@@ -289,9 +289,14 @@ public class StateObserverBlackJack extends ObserverBase implements StateObsNond
         return 0;
     }
 
+    // /WK/ added this. getGameScore(i) needs still to be reshaped.
     @Override
     public ScoreTuple getRewardTuple(boolean rewardIsGameScore) {
-        return null;
+        ScoreTuple sc = new ScoreTuple(this);
+        for (int i=0; i<this.getNumPlayers(); i++) {
+            sc.scTup[i]=this.getGameScore(i);
+        }
+        return sc;
     }
 
     @Override


### PR DESCRIPTION
- MCTSEChanceNode.valueFnc now returns a double vector (content of getRewardTuple)
- backUp in MCTSChanceNode and MCTSTreeNode adapted to backup from a vector double[] delta (like in MCTS, making it fit for N-player games)
- StateObserverBlackJack: extended getRewardTuple to return the gameScore for every player.