### PR TITLE
Improved the click detection

### DIFF
--- a/src/games/CFour/C4GameGui.java
+++ b/src/games/CFour/C4GameGui.java
@@ -265,7 +265,7 @@ public class C4GameGui extends JPanel implements ListOperation {
 //		ImgShowComponent imgShComp = oldImg.replaceImg2(imgIndex);
 		if (oldImg != imgShComp)
 			imgShComp.addMouseListener(new MouseHandler(num1, num2) {
-				public void mouseClicked(MouseEvent e) {
+				public void mouseReleased(MouseEvent e) {
 					handleMouseClick(x, y);
 				}
 			});


### PR DESCRIPTION
Previously, Connect Four did not always smoothly recognize clicks to select a human player's move. Therefore, double clicks were sometimes necessary. However, in some cases, this resulted in the selected column also being selected as the action for the human player's next turn.